### PR TITLE
Always use proper Host header

### DIFF
--- a/src/OwsProxy3/CoreBundle/Component/ProxyQuery.php
+++ b/src/OwsProxy3/CoreBundle/Component/ProxyQuery.php
@@ -7,7 +7,7 @@ use OwsProxy3\CoreBundle\Component\Exception\HTTPStatus403Exception;
 use OwsProxy3\CoreBundle\Component\Exception\HTTPStatus502Exception;
 
 /**
- * ProxyQuery class provides methods for 
+ * ProxyQuery class provides methods for
  *
  * @author A.R.Pour
  * @author Paul Schmidt
@@ -23,7 +23,7 @@ class ProxyQuery
 
     /**
      *
-     * @var string HTTP method (GET/POST) 
+     * @var string HTTP method (GET/POST)
      */
     protected $method;
 
@@ -41,7 +41,7 @@ class ProxyQuery
 
     /**
      *
-     * @var string the POST content 
+     * @var string the POST content
      */
     protected $content;
 
@@ -53,7 +53,7 @@ class ProxyQuery
 
     /**
      * Creates an instance from parameters
-     * 
+     *
      * @param string $url the url
      * @param string $user the user name for basic authentication
      * @param string $password the user password for basic authentication
@@ -62,7 +62,7 @@ class ProxyQuery
      * @param array $postParams the POST parameters
      * @param string $content the POST content
      * @return ProxyQuery a new instance
-     * @throws HTTPStatus502Exception if the host is not defined at $url 
+     * @throws HTTPStatus502Exception if the host is not defined at $url
      */
     public static function createFromUrl($url, $user = null, $password = null,
             $headers = array(), $getParams = array(), $postParams = array(),
@@ -90,13 +90,16 @@ class ProxyQuery
         {
             $method = Utils::$METHOD_POST;
         }
+
+        $headers['Host'] = $rowUrl['host'];
+
         return new ProxyQuery($rowUrl, $method, $content, $getParams,
                 $postParams, $headers);
     }
 
     /**
      * Creates an instance
-     * 
+     *
      * @param Request $request
      * @return ProxyQuery a new instance
      * @throws HTTPStatus502Exception if the host is not defined
@@ -148,13 +151,16 @@ class ProxyQuery
             $getParams     = array_merge($getParams, $getParamshelp);
         }
         $headers = Utils::getHeadersFromRequest($request);
+
+        $headers['Host'] = $rowUrl['host'];
+
         return new ProxyQuery($rowUrl, $method, $content, $getParams,
                 $postParams, $headers);
     }
 
     /**
      * Creates an instance
-     * 
+     *
      * @param array $rowUrl the parsed url (parse_url()) without "query"
      * @param string $method the GET/POST HTTP method
      * @param string $content the POST content
@@ -189,7 +195,7 @@ class ProxyQuery
 
     /**
      * Adds a POST parameter
-     * 
+     *
      * @param string $name
      * @param string $value
      */
@@ -208,7 +214,7 @@ class ProxyQuery
 
     /**
      * Adds a GET parameter
-     * 
+     *
      * @param string $name
      * @param string $value
      */
@@ -227,7 +233,7 @@ class ProxyQuery
 
     /**
      * Adds a POST/GET parameter
-     * 
+     *
      * @param string $name
      * @param string $value
      */
@@ -261,7 +267,7 @@ class ProxyQuery
 
     /**
      * Returns the query string for POST request
-     * 
+     *
      * @return string the query string for POST request
      */
     public function getPostQueryString()
@@ -271,7 +277,7 @@ class ProxyQuery
 
     /**
      * Returns the POST content
-     * 
+     *
      * @return string content
      */
     public function getContent()
@@ -281,7 +287,7 @@ class ProxyQuery
 
     /**
      * Returns the GET/POST method
-     * 
+     *
      * @return string method
      */
     public function getMethod()
@@ -300,7 +306,7 @@ class ProxyQuery
 
     /**
      * Returns the headers
-     * 
+     *
      * @return array headers
      */
     public function getHeaders()
@@ -310,7 +316,7 @@ class ProxyQuery
 
     /**
      * Generats the url for HTTP GET
-     * 
+     *
      * @return string the HTTP GET url
      */
     public function getGetUrl()
@@ -338,7 +344,7 @@ class ProxyQuery
 
     /**
      * Returns the parameter value from GET/POST parameters
-     * 
+     *
      * @param string $name the parameter name
      * @param boolean $ignoreCase to ignore the parameter name case sensitivity
      * @return string|null the parameter value or null
@@ -358,7 +364,7 @@ class ProxyQuery
 
     /**
      * Returns the parameter value from GET parameters
-     * 
+     *
      * @param string $name the parameter name
      * @param boolean $ignoreCase to ignore the parameter name case sensitivity
      * @return string|null the parameter value or null
@@ -391,7 +397,7 @@ class ProxyQuery
 
     /**
      * Returns the parameter value from POST parameters
-     * 
+     *
      * @param string $name the parameter name
      * @param boolean $ignoreCase  to ignore the parameter name case sensitivity
      * @return string|null the parameter value or null
@@ -454,7 +460,7 @@ class ProxyQuery
 
     /**
      * Checks if a GET/POST parameter exists
-     * 
+     *
      * @param string $name the parameter name
      * @param boolean $ignoreCase to ignore the parameter name case sensitivity
      * @return boolean true if a parameter exists
@@ -474,7 +480,7 @@ class ProxyQuery
 
     /**
      * Checks if a GET parameter exists
-     * 
+     *
      * @param string $name the parameter name
      * @param boolean $ignoreCase to ignore the parameter name case sensitivity
      * @return boolean true if a parameter exists
@@ -507,7 +513,7 @@ class ProxyQuery
 
     /**
      * Checks if a POST parameter exists
-     * 
+     *
      * @param string $name the parameter name
      * @param boolean $ignoreCase  to ignore the parameter name case sensitivity
      * @return boolean true if a parameter exists


### PR DESCRIPTION
Forces OWSProxy to always set the Host header. Untested in real proxy environments yet.
