### PR TITLE
Add OWS proxy as Symfony "owsproxy" service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "kriswallsmith/buzz": "v0.15",
         "arsgeografica/signing": "1.1.x"
     },

--- a/src/OwsProxy3/CoreBundle/Component/ProxyService.php
+++ b/src/OwsProxy3/CoreBundle/Component/ProxyService.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace OwsProxy3\CoreBundle\Component;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class ProxyService
+ *
+ * @package OwsProxy3\CoreBundle\Component
+ * @author  Andriy Oblivantsev <eslider@gmail.com>
+ */
+class ProxyService implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * ProxyService constructor.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->setContainer($this->container);
+    }
+
+    /**
+     * /**
+     * Creates an instance from parameters
+     *
+     * @param string $url        URL
+     * @param string $user       User name for basic authentication
+     * @param string $password   User password for basic authentication
+     * @param array  $headers    HTTP headers
+     * @param array  $getParams
+     * @param array  $postParams the POST parameters
+     * @param null   $content
+     * @return \Buzz\Message\MessageInterface|ProxyQuery
+     */
+    public function request($url,
+        $user = null,
+        $password = null,
+        $headers = array(),
+        $getParams = array(),
+        $postParams = array(),
+        $content = null)
+    {
+        $configuration = $this->container->getParameter("owsproxy.proxy");
+        $proxy         = new CommonProxy($configuration, ProxyQuery::createFromUrl(
+            $url,
+            $user,
+            $password,
+            $headers, $getParams, $postParams,
+            $content));
+        return $proxy->handle();
+    }
+}

--- a/src/OwsProxy3/CoreBundle/Resources/config/services.xml
+++ b/src/OwsProxy3/CoreBundle/Resources/config/services.xml
@@ -10,6 +10,9 @@
     </parameters>
 
     <services>        
+        <service id="owsproxy" class="OwsProxy3\CoreBundle\Component\ProxyService">
+            <argument type="service" id="service_container" />
+        </service>
         <service id="owsproxy.terminatelistener" class="%owsproxy.terminatelistener.class%">
             <tag name="kernel.event_listener" event="kernel.terminate" method="onTerminate" />
             <argument type="service" id="service_container" />


### PR DESCRIPTION
I suggests to add OWS proxy routines be able as own service, this can handle requests and returns responce.

New posibility:
```php
$response = $this->container->get("owsproxy")->request($url);
```

And here how we did this before:
* https://github.com/mapbender/mapbender/blob/release/3.0.6/src/Mapbender/CoreBundle/Controller/ApplicationController.php#L390
* https://github.com/mapbender/mapbender/blob/release/3.0.6/src/Mapbender/WmcBundle/Element/WmcLoader.php#L312
* https://github.com/mapbender/mapbender/blob/release/3.0.6/src/Mapbender/PrintBundle/Component/PrintService.php#L1188 