### PR TITLE
Remove deprecated call, fix junk after response body

### DIFF
--- a/src/OwsProxy3/CoreBundle/EventListener/LoggingListener.php
+++ b/src/OwsProxy3/CoreBundle/EventListener/LoggingListener.php
@@ -72,7 +72,7 @@ class LoggingListener
         $log->setResponseCode($event->getResponse()->getStatuscode());
         $log->setResponseSize(strlen($event->getResponse()->getContent()));
 
-        $em = $this->container->get('doctrine')->getEntityManager();
+        $em = $this->container->get('doctrine')->getManager();
         $em->persist($log);
         $em->flush();
     }


### PR DESCRIPTION
One-liner, call to getEntityManager replaced with getManager.
See https://github.com/doctrine/DoctrineBundle/blob/master/Registry.php#L77

Closes #14.
